### PR TITLE
Add adaptive crawler stub integration

### DIFF
--- a/video_recommender/adaptive_crawler.py
+++ b/video_recommender/adaptive_crawler.py
@@ -1,0 +1,64 @@
+from dataclasses import dataclass
+from typing import List, Dict, Optional
+import asyncio
+from bs4 import BeautifulSoup
+
+@dataclass
+class AdaptiveConfig:
+    confidence_threshold: float = 0.7
+    max_depth: int = 5
+    max_pages: int = 20
+    strategy: str = "statistical"
+
+@dataclass
+class VirtualScrollConfig:
+    container_selector: str = ""
+    scroll_count: int = 0
+    scroll_by: str = "container_height"
+    wait_after_scroll: float = 1.0
+
+@dataclass
+class LinkPreviewConfig:
+    query: str
+    score_threshold: float = 0.3
+    concurrent_requests: int = 10
+
+@dataclass
+class SeedingConfig:
+    source: str = "sitemap"
+    pattern: str = ""
+    query: str = ""
+    score_threshold: float = 0.4
+
+class AdaptiveCrawler:
+    """Simplified adaptive crawler using in-memory HTML for demonstration."""
+    def __init__(self, config: Optional[AdaptiveConfig] = None):
+        self.config = config or AdaptiveConfig()
+
+    async def digest(self, start_url: str, query: str) -> Dict[str, List[Dict[str, str]]]:
+        """Return simulated crawl results with video titles and URLs."""
+        await asyncio.sleep(0.1)
+        sample_html = """
+        <html><body>
+        <a href='https://videos.example.com/1'>Example Video 1</a>
+        <a href='https://videos.example.com/2'>Example Video 2</a>
+        <a href='https://videos.example.com/3'>Example Video 3</a>
+        </body></html>
+        """
+        soup = BeautifulSoup(sample_html, "html.parser")
+        videos = []
+        for tag in soup.find_all("a"):
+            title = tag.text.strip()
+            url = tag.get("href", "")
+            if title and url:
+                videos.append({"title": title, "url": url})
+        return {"videos": videos}
+
+class AsyncUrlSeeder:
+    """Discover URLs asynchronously (stub implementation)."""
+    def __init__(self, config: SeedingConfig):
+        self.config = config
+
+    async def discover(self, base_url: str) -> List[str]:
+        await asyncio.sleep(0.05)
+        return [f"{base_url}/video/{i}" for i in range(1, 4)]

--- a/video_recommender/scrapers.py
+++ b/video_recommender/scrapers.py
@@ -256,34 +256,25 @@ class Crawl4aiVideoScraper:
             Exception: Various network, parsing, or validation errors
         """
         try:
-            # Log the configuration being used
-            logger.debug(f"Crawl4AI config: site={flow_def.get('site')}, "
-                        f"user_agent={flow_def.get('user_agent', 'default')[:50]}...")
-            
-            # Simulate network delay
-            await asyncio.sleep(0.1)
-            
-            # In real implementation, this is where Crawl4AI would:
-            # 1. Make HTTP request with configured settings
-            # 2. Handle redirects and cookies
-            # 3. Parse HTML/JavaScript if needed
-            # 4. Extract data using CSS selectors
-            # 5. Validate and format results
-            
-            # For now, simulate occasional failures and empty results
-            import random
-            if random.random() < 0.1:  # 10% chance of simulated failure
-                raise Exception("Simulated network error")
-            
-            # Most of the time return empty results (since this is placeholder)
-            return {
-                'videos': [],
-                'total_found': 0,
+            logger.debug(
+                f"Crawl4AI config: site={flow_def.get('site')}, "
+                f"user_agent={flow_def.get('user_agent', 'default')[:50]}..."
+            )
+
+            from .adaptive_crawler import AdaptiveCrawler, AdaptiveConfig
+
+            crawler = AdaptiveCrawler(AdaptiveConfig())
+            results = await crawler.digest(flow_def.get('url', ''), flow_def.get('query', ''))
+
+            results.update({
+                'total_found': len(results.get('videos', [])),
                 'site': flow_def.get('site', 'unknown'),
                 'url': flow_def.get('url', ''),
                 'success': True
-            }
-            
+            })
+
+            return results
+
         except Exception as e:
             logger.debug(f"Simulated crawl4ai error: {e}")
             raise


### PR DESCRIPTION
## Summary
- add `adaptive_crawler` with config dataclasses and simple async crawler
- integrate AdaptiveCrawler into scraper to return sample titles and URLs

## Testing
- `python -m py_compile video_recommender/*.py video_recommender_main.py cli.py newvideo.py crawl4ai_settings.py`

------
https://chatgpt.com/codex/tasks/task_e_687eef33275c8329a0d42b17de497068